### PR TITLE
Improve error reporting in recording

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -152,6 +152,7 @@ class WhisperWriterApp(QObject):
             self.result_thread.statusSignal.connect(self.status_window.updateStatus)
             self.status_window.closeSignal.connect(self.stop_result_thread)
         self.result_thread.resultSignal.connect(self.on_transcription_complete)
+        self.result_thread.errorSignal.connect(self.show_error_message)
         self.result_thread.start()
 
     def stop_result_thread(self):
@@ -174,6 +175,10 @@ class WhisperWriterApp(QObject):
             self.start_result_thread()
         else:
             self.key_listener.start()
+
+    def show_error_message(self, message):
+        """Display an error message from the result thread."""
+        QMessageBox.critical(self.main_window, 'Recording Error', message)
 
     def run(self):
         """

--- a/src/result_thread.py
+++ b/src/result_thread.py
@@ -14,23 +14,17 @@ from utils import ConfigManager
 
 
 class ResultThread(QThread):
-    """
-    A thread class for handling audio recording, transcription, and result processing.
+    """Thread for recording and transcribing audio."""
 
-    This class manages the entire process of:
-    1. Recording audio from the microphone
-    2. Detecting speech and silence
-    3. Saving the recorded audio as numpy array
-    4. Transcribing the audio
-    5. Emitting the transcription result
-
-    Signals:
-        statusSignal: Emits the current status of the thread (e.g., 'recording', 'transcribing', 'idle')
-        resultSignal: Emits the transcription result
-    """
-
+    # Emitted whenever the internal state changes.
     statusSignal = pyqtSignal(str)
+
+    # Emitted when a transcription result is available.
     resultSignal = pyqtSignal(str)
+
+    # Emitted when an exception occurs while processing audio. The signal carries
+    # a human readable error message so the UI can inform the user.
+    errorSignal = pyqtSignal(str)
 
     def __init__(self, local_model=None):
         """
@@ -100,6 +94,7 @@ class ResultThread(QThread):
         except Exception as e:
             traceback.print_exc()
             self.statusSignal.emit('error')
+            self.errorSignal.emit(str(e))
             self.resultSignal.emit('')
         finally:
             self.stop_recording()


### PR DESCRIPTION
## Summary
- surface recording exceptions via `errorSignal`
- connect new error signal to the main window and display errors

## Testing
- `python -m py_compile src/main.py src/result_thread.py`

------
https://chatgpt.com/codex/tasks/task_e_685c08d52660832eab7e10ae9633cf5e